### PR TITLE
Fix HotSpot Country disappearing when country displayed

### DIFF
--- a/static/hotspot.js
+++ b/static/hotspot.js
@@ -179,12 +179,16 @@ var getCountrySummary = function(countryName) {
   reqCountrySummary.send(null);
   emptyCountry();
 };
+
 var emptyCountry = function() {
   var myNode = document.getElementById("country");
   while (myNode.firstChild) {
      myNode.removeChild(myNode.firstChild);
   }
-  myNode = document.getElementById("world");
+};
+
+var emptyWorld = function() {
+  var myNode = document.getElementById("world");
   while (myNode.firstChild) {
      myNode.removeChild(myNode.firstChild);
   }
@@ -192,6 +196,7 @@ var emptyCountry = function() {
 
 var kickOff = function() {
   emptyCountry();
+  emptyWorld();
   worldHotspots(c);
 };
 


### PR DESCRIPTION
At some point it looks like I add cleaning up the world div when it should only clean the country.

I separated the clean-up into two function and added an additional call to clean the world on kick off.

@priyanka57 This would be a good chance to review and merge a pull request. :grinning: 
